### PR TITLE
Space Science Threshold update

### DIFF
--- a/GameData/SigmaDimensions/Configs/ReDimension/advancedSettings.cfg
+++ b/GameData/SigmaDimensions/Configs/ReDimension/advancedSettings.cfg
@@ -56,6 +56,10 @@
 {
 	%scanAltitude = 1
 }
+@SigmaDimensions:HAS[~scienceAltitudeThreshold[>0]]:AFTER[SigDim]
+{
+	%scienceAltitudeThreshold = 1
+}
 @SigmaDimensions:HAS[~resizeBuildings[>0],#Resize[<1]]:AFTER[SigDim]
 {
 	%resizeBuildings = #$Resize$

--- a/GameData/SigmaDimensions/Configs/ReDimension/applySettings.cfg
+++ b/GameData/SigmaDimensions/Configs/ReDimension/applySettings.cfg
@@ -33,5 +33,15 @@
 		{
 			@lightRange *= #$Rescale$
 		}
+		
+		// Space Science Rescale
+		@SigmaDimensions
+		{
+			%scienceAltitude = #$Rescale$
+			@scienceAltitude *= #$Resize$
+			@scienceAltitude != 0.5
+			@scienceAltitudeThreshold *= #$scienceAltitude$
+			!scienceAltitude = DEL
+		}
 	}
 }

--- a/GameData/SigmaDimensions/Configs/ReDimension/setDimensions.cfg
+++ b/GameData/SigmaDimensions/Configs/ReDimension/setDimensions.cfg
@@ -34,13 +34,6 @@
 	{
 		@Properties
 		{
-			@ScienceValues
-			{
-				@spaceAltitudeThreshold += #$../radius$
-			}
-		}
-		@Properties
-		{
 			@radius *= #$../SigmaDimensions/Resize$
 			@geeASL *= #$../SigmaDimensions/geeASLmultiplier$
 			@rotationPeriod *= #$../SigmaDimensions/dayLengthMultiplier$
@@ -48,8 +41,7 @@
 			@ScienceValues
 			{
 				@flyingAltitudeThreshold *= #$../../SigmaDimensions/Atmosphere$
-				@spaceAltitudeThreshold *= #$../../SigmaDimensions/Rescale$
-				@spaceAltitudeThreshold -= #$../radius$
+				@spaceAltitudeThreshold *= #$../../SigmaDimensions/scienceAltitudeThreshold$
 			}
 		}
 		@Orbit

--- a/GameData/SigmaDimensions/README.txt
+++ b/GameData/SigmaDimensions/README.txt
@@ -161,6 +161,13 @@ Altitude limits for orbital scanners is multiplied by the "Resize" and "scanAlti
 
 ---
 
+# scienceAltitudeThreshold (default value = 1)
+
+- Can be set to any positive number.
+
+Altitude limits for the border between low and high space is multiplied by "scienceAltitudeThreshold", and the square root of "Resize" times "Rescale".
+
+---
 
 
 

--- a/GameData/SigmaDimensions/Settings.cfg
+++ b/GameData/SigmaDimensions/Settings.cfg
@@ -28,4 +28,5 @@ SigmaDimensions
 	lightRange = 1
 	
 	scanAltitude = 1
+	scienceAltitudeThreshold = 1
 }

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ The SigmaDimensions settings node contains both Base and Advanced settings:
     Altitude limits for orbital scanners is multiplied by the "Resize" and "scanAltitude" parameters.
     ```
 
+  - **scienceAltitudeThreshold**, *\<double\>*, *default value = 1*, Can be set to any positive number.
+
+    ```
+    Altitude limits for the border between low and high space is multiplied by "scienceAltitudeThreshold", and the square root of "Resize" times "Rescale".
+    ```
+
   - **debug**, *\<bool\>*, *default value = false*
   
     <pre>


### PR DESCRIPTION
Can no longer set the value of spaceAltitudeThreshold negative with mixed resize/rescale settings. Should have the same values as before with matching resize/rescales. Also now has an adjustable setting for user control.

new spaceAltitudeThreshold = base spaceAltitudeThreshold * (sqrt(Resize * Rescale) * scienceAltitudeThreshold)

Old formula was spaceAltitudeThreshold = ((base body radius + base spaceAltitudeThreshold) * Rescale) - modified body radius.