### PR TITLE
Reduce MM patch count

### DIFF
--- a/GameData/SigmaDimensions/Configs/ReDimension/rescaleAntennas.cfg
+++ b/GameData/SigmaDimensions/Configs/ReDimension/rescaleAntennas.cfg
@@ -1,4 +1,4 @@
-@PART:FOR[SigDim2]
+@PART:HAS[@MODULE[ModuleDataTransmitter*]]:FOR[SigDim2]
 {
 	@MODULE:HAS[#name[ModuleDataTransmitter*]]
 	{

--- a/GameData/SigmaDimensions/Configs/ReDimension/rescaleSCANsat.cfg
+++ b/GameData/SigmaDimensions/Configs/ReDimension/rescaleSCANsat.cfg
@@ -2,7 +2,7 @@
 {
 	@scanAltitude *= #$@SigmaDimensions/Resize$
 }
-@PART:FOR[SigDim2]
+@PART:HAS[@MODULE[ModuleSCANresourceScanner]]:FOR[SigDim2]
 {
 	@MODULE:HAS[#name[ModuleSCANresourceScanner]]
 	{
@@ -10,16 +10,25 @@
 		@max_alt *= #$@SigmaDimensions/scanAltitude$
 		@best_alt *= #$@SigmaDimensions/scanAltitude$
 	}
+}
+@PART:HAS[@MODULE[SCANsat]]:FOR[SigDim2]
+{
 	@MODULE:HAS[#name[SCANsat]]
 	{
 		@min_alt *= #$@SigmaDimensions/scanAltitude$
 		@max_alt *= #$@SigmaDimensions/scanAltitude$
 		@best_alt *= #$@SigmaDimensions/scanAltitude$
 	}
+}
+@PART:HAS[@MODULE[ModuleResourceScanner]]:FOR[SigDim2]
+{
 	@MODULE:HAS[#name[ModuleResourceScanner]]
 	{
 		@MaxAbundanceAltitude *= #$@SigmaDimensions/scanAltitude$
 	}
+}
+@PART:HAS[@MODULE[ModuleOrbitalSurveyor]]:FOR[SigDim2]
+{	
 	@MODULE:HAS[#name[ModuleOrbitalSurveyor]]
 	{
 		@minThreshold *= #$@SigmaDimensions/scanAltitude$


### PR DESCRIPTION
Patch the antenna and SCANsat modules only on parts that actually have any of these modules, which shouldn't have any effect other than reducing the amount of useless "patches" written in the log / displayed during loading.